### PR TITLE
Get file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2762,7 +2762,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2783,12 +2784,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2803,17 +2806,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2930,7 +2936,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2942,6 +2949,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2956,6 +2964,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2963,12 +2972,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2987,6 +2998,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3067,7 +3079,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3079,6 +3092,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3164,7 +3178,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3200,6 +3215,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3219,6 +3235,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3262,12 +3279,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3972,7 +3991,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2762,8 +2762,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2784,14 +2783,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2806,20 +2803,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2936,8 +2930,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2949,7 +2942,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2964,7 +2956,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2972,14 +2963,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2998,7 +2987,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3079,8 +3067,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3092,7 +3079,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3178,8 +3164,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3215,7 +3200,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3235,7 +3219,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3279,14 +3262,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3991,8 +3972,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",

--- a/src/File/__tests__/file.spec.ts
+++ b/src/File/__tests__/file.spec.ts
@@ -85,7 +85,6 @@ describe('File class', () => {
         'base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9',
         true,
       );
-      const body = mock.calls[0][1].body;
       expect(mock.calls[0][0]).toEqual(
         `${baseUrl}/files/myOrg/myProject/base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9`,
       );

--- a/src/File/__tests__/file.spec.ts
+++ b/src/File/__tests__/file.spec.ts
@@ -57,6 +57,42 @@ describe('File class', () => {
     });
   });
 
+  describe('File.getSelf()', () => {
+    it('should GET the new file with the expected payload', async () => {
+      mockResponse(JSON.stringify(mockFileResponse), { status: 200 });
+      const selfURL =
+        'https://nexus.example.com/v1/files/myorg/myproj/base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9';
+      const file: NexusFile = await NexusFile.getSelf(
+        selfURL,
+        'myOrg',
+        'myProject',
+      );
+      expect(mock.calls[0][0]).toEqual(selfURL);
+      expect(file).toBeInstanceOf(NexusFile);
+      expect(file.id).toEqual('base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9');
+      expect(file.rawFile).toEqual(undefined);
+    });
+
+    it('should GET the new file with the optional fetchFile flag', async () => {
+      mockResponses(
+        [JSON.stringify(mockFileResponse), { status: 200 }],
+        ['some text', { status: 200 }],
+      );
+      const selfURL =
+        'https://nexus.example.com/v1/files/myorg/myproj/base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9';
+      const file: NexusFile = await NexusFile.getSelf(
+        selfURL,
+        'myOrg',
+        'myProject',
+        true,
+      );
+      expect(mock.calls[0][0]).toEqual(selfURL);
+      expect(file).toBeInstanceOf(NexusFile);
+      expect(file.id).toEqual('base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9');
+      expect(file.rawFile).toEqual('some text');
+    });
+  });
+
   describe('File.get()', () => {
     it('should GET the new file with the expected payload', async () => {
       mockResponse(JSON.stringify(mockFileResponse), { status: 200 });
@@ -65,7 +101,6 @@ describe('File class', () => {
         'myProject',
         'base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9',
       );
-      const body = mock.calls[0][1].body;
       expect(mock.calls[0][0]).toEqual(
         `${baseUrl}/files/myOrg/myProject/base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9`,
       );

--- a/src/File/__tests__/file.spec.ts
+++ b/src/File/__tests__/file.spec.ts
@@ -1,4 +1,4 @@
-import { resetMocks, mock, mockResponse } from 'jest-fetch-mock';
+import { resetMocks, mock, mockResponse, mockResponses } from 'jest-fetch-mock';
 import Nexus from '../..';
 import NexusFile from '../index';
 import { NexusFileResponse } from '../types';
@@ -8,7 +8,8 @@ import fs from 'fs';
 const baseUrl = 'http://api.url';
 Nexus.setEnvironment(baseUrl);
 
-const mockPostFileResponse: NexusFileResponse = {
+// for both POST and GET it will look the same
+const mockFileResponse: NexusFileResponse = {
   '@context': 'https://bluebrain.github.io/nexus/contexts/resource.json',
   '@id': 'base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9',
   '@type': 'File',
@@ -37,18 +38,14 @@ describe('File class', () => {
   });
   describe('It should create a File instance', () => {
     it('from a getByID example response', () => {
-      const resource = new NexusFile(
-        'testOrg',
-        'testProject',
-        mockPostFileResponse,
-      );
-      expect(resource).toMatchSnapshot();
+      const file = new NexusFile('testOrg', 'testProject', mockFileResponse);
+      expect(file).toMatchSnapshot();
     });
   });
 
   describe('File.create()', () => {
     it('should POST the new file with the expected payload', async () => {
-      mockResponse(JSON.stringify(mockPostFileResponse), { status: 200 });
+      mockResponse(JSON.stringify(mockFileResponse), { status: 200 });
       const buffer = new Buffer('abc');
       const stream = new Readable();
       stream.push(buffer);
@@ -57,6 +54,55 @@ describe('File class', () => {
       await NexusFile.create('myOrg', 'myProject', stream);
       const body = mock.calls[0][1].body;
       expect(body._overheadLength).toBe(143);
+    });
+  });
+
+  describe('File.get()', () => {
+    it('should GET the new file with the expected payload', async () => {
+      mockResponse(JSON.stringify(mockFileResponse), { status: 200 });
+      const file: NexusFile = await NexusFile.get(
+        'myOrg',
+        'myProject',
+        'base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9',
+      );
+      const body = mock.calls[0][1].body;
+      expect(mock.calls[0][0]).toEqual(
+        `${baseUrl}/files/myOrg/myProject/base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9`,
+      );
+      expect(file).toBeInstanceOf(NexusFile);
+      expect(file.id).toEqual('base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9');
+      expect(file.rawFile).toEqual(undefined);
+    });
+
+    it('should GET the actual file if you add the optional flag', async () => {
+      mockResponses(
+        [JSON.stringify(mockFileResponse), { status: 200 }],
+        ['some text', { status: 200 }],
+      );
+      const file: NexusFile = await NexusFile.get(
+        'myOrg',
+        'myProject',
+        'base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9',
+        true,
+      );
+      const body = mock.calls[0][1].body;
+      expect(mock.calls[0][0]).toEqual(
+        `${baseUrl}/files/myOrg/myProject/base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9`,
+      );
+      expect(file).toBeInstanceOf(NexusFile);
+      expect(file.id).toEqual('base:d8848d4c-68f7-4ffd-952f-63a8cbcb86a9');
+      expect(file.rawFile).toEqual('some text');
+    });
+  });
+
+  describe('File.getFile()', () => {
+    it('should request the raw file', async () => {
+      mockResponse('randombytesofdata', { status: 200 });
+      const file = new NexusFile('testOrg', 'testProject', mockFileResponse);
+      await file.getFile();
+      const headers = mock.calls[0][1].headers;
+      expect(headers).not.toHaveProperty('Accept');
+      expect(file.rawFile).toEqual('randombytesofdata');
     });
   });
 });

--- a/src/File/index.ts
+++ b/src/File/index.ts
@@ -1,6 +1,7 @@
 import { NexusFileResponse } from './types';
-import { createFile } from './utils';
+import { createFile, getFile, getRawFile } from './utils';
 import { Context } from '../Resource/types';
+import { ReadStream } from 'fs';
 
 export default class NexusFile {
   readonly orgLabel: string;
@@ -25,8 +26,10 @@ export default class NexusFile {
   };
   readonly bytes: number;
   readonly raw: NexusFileResponse;
+  public rawFile?: string | Blob | ArrayBuffer | ReadStream;
 
   static create = createFile;
+  static get = getFile;
 
   constructor(
     orgLabel: string,
@@ -55,5 +58,9 @@ export default class NexusFile {
     };
     this.filename = fileResponse._filename;
     this.mediaType = fileResponse._mediaType;
+  }
+
+  async getFile() {
+    this.rawFile = await getRawFile(this.orgLabel, this.projectLabel, this.id);
   }
 }

--- a/src/File/index.ts
+++ b/src/File/index.ts
@@ -62,6 +62,6 @@ export default class NexusFile {
   }
 
   async getFile() {
-    this.rawFile = await getRawFile(this.orgLabel, this.projectLabel, this.id);
+    this.rawFile = await getRawFile(this.self);
   }
 }

--- a/src/File/index.ts
+++ b/src/File/index.ts
@@ -1,5 +1,5 @@
 import { NexusFileResponse } from './types';
-import { createFile, getFile, getRawFile } from './utils';
+import { createFile, getFile, getRawFile, getFileSelf } from './utils';
 import { Context } from '../Resource/types';
 import { ReadStream } from 'fs';
 
@@ -30,6 +30,7 @@ export default class NexusFile {
 
   static create = createFile;
   static get = getFile;
+  static getSelf = getFileSelf;
 
   constructor(
     orgLabel: string,

--- a/src/File/types.ts
+++ b/src/File/types.ts
@@ -14,8 +14,8 @@ export interface NexusFileResponse {
   _self: string;
   _constrainedBy: string;
   _project: string;
-  _rev: 1;
-  _deprecated: false;
+  _rev: number;
+  _deprecated: boolean;
   _createdAt: string;
   _createdBy: string;
   _updatedAt: string;

--- a/src/File/utils.ts
+++ b/src/File/utils.ts
@@ -69,17 +69,16 @@ export async function getFile(
 }
 
 export async function getRawFile(
-  orgLabel: string,
-  projectLabel: string,
-  fileId: string,
+  selfURL: string,
 ): Promise<string | Blob | ReadStream | ArrayBuffer> {
   const rawFile: string | Blob | ReadStream | ArrayBuffer = await httpGet(
-    `/files/${orgLabel}/${projectLabel}/${fileId}`,
+    selfURL,
     {
+      useBase: false,
       extraHeaders: {
         Accept: null,
       },
-      receiveAs: HttpConfigTypes.FILE,
+      receiveAs: HttpConfigTypes.BASE64,
     },
   );
   return rawFile;

--- a/src/File/utils.ts
+++ b/src/File/utils.ts
@@ -36,6 +36,22 @@ export async function createFile(
   }
 }
 
+export async function getFileSelf(
+  selfUrl: string,
+  orgLabel: string,
+  projectLabel: string,
+  shouldFetchFile: boolean = false,
+): Promise<NexusFile> {
+  const fileResponse: NexusFileResponse = await httpGet(selfUrl, {
+    useBase: false,
+  });
+  const file = new NexusFile(orgLabel, projectLabel, fileResponse);
+  if (shouldFetchFile) {
+    await file.getFile();
+  }
+  return file;
+}
+
 export async function getFile(
   orgLabel: string,
   projectLabel: string,

--- a/src/File/utils.ts
+++ b/src/File/utils.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import FormData from 'isomorphic-form-data';
 import { NexusFileResponse } from './types';
-import { httpPost, HttpConfigTypes } from '../utils/http';
+import { httpPost, HttpConfigTypes, httpGet } from '../utils/http';
 import NexusFile from './index';
 import { isBrowser } from '../utils';
 import { ReadStream } from 'fs';
@@ -34,4 +34,37 @@ export async function createFile(
   } catch (error) {
     throw error;
   }
+}
+
+export async function getFile(
+  orgLabel: string,
+  projectLabel: string,
+  fileId: string,
+  shouldFetchFile: boolean = false,
+): Promise<NexusFile> {
+  const fileResponse: NexusFileResponse = await httpGet(
+    `/files/${orgLabel}/${projectLabel}/${fileId}`,
+  );
+  const file = new NexusFile(orgLabel, projectLabel, fileResponse);
+  if (shouldFetchFile) {
+    await file.getFile();
+  }
+  return file;
+}
+
+export async function getRawFile(
+  orgLabel: string,
+  projectLabel: string,
+  fileId: string,
+): Promise<string | Blob | ReadStream | ArrayBuffer> {
+  const rawFile: string | Blob | ReadStream | ArrayBuffer = await httpGet(
+    `/files/${orgLabel}/${projectLabel}/${fileId}`,
+    {
+      extraHeaders: {
+        Accept: null,
+      },
+      receiveAs: HttpConfigTypes.FILE,
+    },
+  );
+  return rawFile;
 }

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -288,7 +288,7 @@ export async function deprecateSelfResource(
   try {
     const resourceResponse: ResourceResponse = await httpDelete(
       `${selfUrl}?rev=${rev}`,
-      false,
+      { useBase: false },
     );
     return new Resource(orgLabel, projectLabel, resourceResponse);
   } catch (error) {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -85,13 +85,12 @@ function prepareResponse(
   as: httpTypes = HttpConfigTypes.JSON,
 ): any {
   switch (as) {
-    case HttpConfigTypes.TEXT:
-      return response.text();
     case HttpConfigTypes.JSON:
       return jsonParser(response);
     case HttpConfigTypes.FILE:
+    case HttpConfigTypes.TEXT:
     default:
-      return response;
+      return response.text();
   }
 }
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -87,7 +87,6 @@ async function prepareResponse(
       let binary = '';
       const bytes = [].slice.call(new Uint8Array(aBuff));
       bytes.forEach((b: any) => (binary += String.fromCharCode(b)));
-      console.log(bytes);
       return btoa(binary);
     case HttpConfigTypes.TEXT:
     default:


### PR DESCRIPTION
# NEW
`NexusFile.get()` will let you fetch a file's metaData as a NexusFile instance, provided you have an id, with an option to also request the rawFile (stored under instance `nexusFile.rawFile`)

`NexusFile.getSelf()` will let you fetch a file's metaData as a NexusFile instance, provided you have a selfURL (the absolute url), with an option to also request the rawFile (stored under instance `nexusFile.rawFile`)

If you already have a nexusFile instance, then you can use the method `nexusFile.getFile()` to fetch the raw file data and put int under the `rawFile` instance property. 