### PR TITLE
Get Resource as Expanded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",

--- a/src/Resource/__tests__/Resource.spec.ts
+++ b/src/Resource/__tests__/Resource.spec.ts
@@ -208,6 +208,22 @@ describe('Resource class', () => {
         `${baseUrl}/resources/myorg/myproject/myschema/myresource`,
       );
       expect(r).toBeInstanceOf(Resource);
+      expect(r).toHaveProperty('expanded', false);
+    });
+
+    it('should call httpGet method with the proper get views url for expanded', async () => {
+      const r: Resource = await getResource(
+        'myorg',
+        'myproject',
+        'myschema',
+        'myresource',
+        { expanded: true },
+      );
+      expect(mock.calls[0][0]).toEqual(
+        `${baseUrl}/resources/myorg/myproject/myschema/myresource?format=expanded`,
+      );
+      expect(r).toBeInstanceOf(Resource);
+      expect(r).toHaveProperty('expanded', true);
     });
   });
 

--- a/src/Resource/index.ts
+++ b/src/Resource/index.ts
@@ -1,4 +1,9 @@
-import { Context, ResourceResponse, ResourceGetFormats } from './types';
+import {
+  Context,
+  ResourceResponse,
+  ResourceGetFormats,
+  GetResourceOptions,
+} from './types';
 import {
   getResource,
   getSelfResource,
@@ -14,6 +19,10 @@ import {
   listTags,
   listSelfTags,
 } from './utils';
+
+export const DEFAULT_GET_RESOURCE_OPTIONS: GetResourceOptions = {
+  expanded: false,
+};
 
 export const RESOURCE_METADATA_KEYS = [
   '@context',
@@ -48,6 +57,7 @@ export default class Resource<T = {}> {
   readonly data: T;
   readonly raw: ResourceResponse;
   readonly resourceURL: string;
+  readonly expanded: boolean;
 
   static getSelf = getSelfResource;
   static getSelfRawAs = getSelfResourceRawAs;
@@ -79,6 +89,7 @@ export default class Resource<T = {}> {
     orgLabel: string,
     projectLabel: string,
     resourceResponse: ResourceResponse,
+    getResourceOptions: GetResourceOptions = DEFAULT_GET_RESOURCE_OPTIONS,
   ) {
     this.raw = resourceResponse;
     this.orgLabel = orgLabel;
@@ -94,6 +105,7 @@ export default class Resource<T = {}> {
     this.updatedBy = resourceResponse._updatedBy;
     this.rev = resourceResponse._rev;
     this.deprecated = resourceResponse._deprecated;
+    this.expanded = getResourceOptions.expanded;
     // make type an array of sting, even if we only get a single string
     if (resourceResponse['@type']) {
       if (Array.isArray(resourceResponse['@type'])) {

--- a/src/Resource/types.ts
+++ b/src/Resource/types.ts
@@ -75,3 +75,7 @@ export type ResourceGetFormats =
   | ResourceGetFormat.DOT
   | ResourceGetFormat.JSON_LD
   | ResourceGetFormat.N_TRIPLES;
+
+export interface GetResourceOptions {
+  expanded: boolean;
+}

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -1,5 +1,5 @@
 import { PaginatedList } from '..';
-import Resource from '.';
+import Resource, { DEFAULT_GET_RESOURCE_OPTIONS } from '.';
 import {
   httpGet,
   httpPut,
@@ -17,6 +17,7 @@ import {
   Context,
   ResourceGetFormat,
   ResourceGetFormats,
+  GetResourceOptions,
 } from './types';
 import { buildQueryParams } from '../utils';
 
@@ -47,12 +48,19 @@ export async function getSelfResource(
   selfUrl: string,
   orgLabel: string,
   projectLabel: string,
+  getResourceOptions: GetResourceOptions = DEFAULT_GET_RESOURCE_OPTIONS,
 ): Promise<Resource> {
   try {
-    const resourceResponse: ResourceResponse = await getSelfResourceRawAs(
-      selfUrl,
+    const url = `${selfUrl}${
+      getResourceOptions.expanded ? '?format=expanded' : ''
+    }`;
+    const resourceResponse: ResourceResponse = await getSelfResourceRawAs(url);
+    const resource = new Resource(
+      orgLabel,
+      projectLabel,
+      resourceResponse,
+      getResourceOptions,
     );
-    const resource = new Resource(orgLabel, projectLabel, resourceResponse);
     return resource;
   } catch (error) {
     throw error;
@@ -64,13 +72,21 @@ export async function getResource(
   projectLabel: string,
   schemaId: string,
   resourceId: string,
+  getResourceOptions: GetResourceOptions = DEFAULT_GET_RESOURCE_OPTIONS,
 ): Promise<Resource> {
-  const projectResourceURL = `/resources/${orgLabel}/${projectLabel}/${schemaId}/${resourceId}`;
+  const projectResourceURL = `/resources/${orgLabel}/${projectLabel}/${schemaId}/${resourceId}${
+    getResourceOptions.expanded ? '?format=expanded' : ''
+  }`;
   try {
     const resourceResponse: ResourceResponse = await httpGet(
       projectResourceURL,
     );
-    const resource = new Resource(orgLabel, projectLabel, resourceResponse);
+    const resource = new Resource(
+      orgLabel,
+      projectLabel,
+      resourceResponse,
+      getResourceOptions,
+    );
     return resource;
   } catch (error) {
     throw error;


### PR DESCRIPTION
# New
You now fetch resources in expanded formats

```typescript
const resource: Resource = await getResource(
        'myorg',
        'myproject',
        'myschema',
        'myresource',
        { expanded: true },
      );

resource.expanded // true
```

You can also use the get self static method
```typescript
const r: Resource = await Resource.getSelf(
        'http://myurl.com',
        'myorg',
        'myproject',
        { expanded: true },
      );
```
