### PR TITLE
👷‍♀️FIX: fixify link pagination settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",

--- a/src/Resource/__tests__/links.spec.ts
+++ b/src/Resource/__tests__/links.spec.ts
@@ -9,7 +9,7 @@ import {
 import { SparqlViewQueryResponse } from '../../View/SparqlView/types';
 import { PaginatedList } from '../../utils/types';
 import { ResourceLink } from '../types';
-import { getIncomingLinks, getOutgoingLinks } from '../utils';
+import { getIncomingLinks, getOutgoingLinks, getLinks } from '../utils';
 
 const { fetchMock } = <GlobalWithFetchMock>global;
 
@@ -145,6 +145,31 @@ const mockOutgoingLinksQueryResponse: SparqlViewQueryResponse = {
 };
 
 describe('Incoming / Outgoing Links behavior', () => {
+  describe('getLinks()', () => {
+    it('should output PaginationSettings with total as a number', async () => {
+      fetchMock.mockResponses(
+        [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
+        [JSON.stringify(mockIncomingLinksQueryResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+      );
+
+      const links: PaginatedList<ResourceLink> = await getLinks(
+        'myOrg',
+        'myProject',
+        {
+          from: 0,
+          size: 20,
+        },
+        () => 'Pretend that I am a great sparql query!',
+      );
+
+      expect(links.results[0]).toHaveProperty('predicate');
+      expect(links.results[0]).toHaveProperty('link');
+      expect(links.total).toBe(2);
+      fetchMock.resetMocks();
+    });
+  });
   describe('getIncomingLinks()', () => {
     it('should fetch a PaginatedList of ResourceLinks using the proper SPAQRL queries as instance method', async () => {
       const resource = new Resource<{
@@ -152,10 +177,10 @@ describe('Incoming / Outgoing Links behavior', () => {
       }>('testOrg', 'testProject', mockGetByIDResourceResponse);
 
       fetchMock.mockResponses(
-        [JSON.stringify(mockSparqlViewResponse), {status: 200}],
-        [JSON.stringify(mockIncomingLinksQueryResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
+        [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
+        [JSON.stringify(mockIncomingLinksQueryResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
       );
       const links: PaginatedList<
         ResourceLink
@@ -173,10 +198,10 @@ describe('Incoming / Outgoing Links behavior', () => {
 
     it('should work as a static method', async () => {
       fetchMock.mockResponses(
-        [JSON.stringify(mockSparqlViewResponse), {status: 200}],
-        [JSON.stringify(mockIncomingLinksQueryResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
+        [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
+        [JSON.stringify(mockIncomingLinksQueryResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
       );
       const links: PaginatedList<
         ResourceLink
@@ -205,11 +230,11 @@ describe('Incoming / Outgoing Links behavior', () => {
       }>('testOrg', 'testProject', mockGetByIDResourceResponse);
 
       fetchMock.mockResponses(
-        [JSON.stringify(mockSparqlViewResponse), {status: 200}],
-        [JSON.stringify(mockOutgoingLinksQueryResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
+        [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
+        [JSON.stringify(mockOutgoingLinksQueryResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
       );
       const links: PaginatedList<
         ResourceLink
@@ -227,11 +252,11 @@ describe('Incoming / Outgoing Links behavior', () => {
 
     it('should work just as well as a static method', async () => {
       fetchMock.mockResponses(
-        [JSON.stringify(mockSparqlViewResponse), {status: 200}],
-        [JSON.stringify(mockOutgoingLinksQueryResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
-        [JSON.stringify(mockResourceResponse), {status: 200}],
+        [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
+        [JSON.stringify(mockOutgoingLinksQueryResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
       );
       const links: PaginatedList<ResourceLink> = await getOutgoingLinks(
         'myorg',

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -471,7 +471,7 @@ export async function getLinks(
       });
       const resources = await Promise.all(resourcePromises);
       return {
-        total: totalBinding ? totalBinding.total.value : 0,
+        total: +(totalBinding ? totalBinding.total.value : 0),
         index: from,
         results: queryResults.map((subjectPredicate, index) => {
           return {

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -473,9 +473,7 @@ export async function getLinks(
       );
       const resources = await Promise.all(resourcePromises);
       return {
-        // total must be a number, so we use + to cast the string
-        // such as "2" into the number 2
-        total: +(totalBinding ? totalBinding.total.value : 0),
+        total: Number(totalBinding ? totalBinding.total.value : 0),
         index: from,
         results: queryResults.map((subjectPredicate, index) => {
           return {

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -456,21 +456,25 @@ export async function getLinks(
         binding => typeof binding['total'] === 'undefined',
       );
 
-      const resourcePromises = queryResults.map(subjectPredicate => {
-        // depending on incoming or outgoing, we'll center on subject or object
-        const graphID = (subjectPredicate.s || subjectPredicate.o).value;
+      const resourcePromises: Promise<string | Resource>[] = queryResults.map(
+        subjectPredicate => {
+          // depending on incoming or outgoing, we'll center on subject or object
+          const graphID = (subjectPredicate.s || subjectPredicate.o).value;
 
-        // self exists here, so we can assume that
-        // it is a resource in the platform
-        if (!!subjectPredicate.self) {
-          return Resource.getSelf(subjectPredicate.self.value);
-        }
+          // self exists here, so we can assume that
+          // it is a resource in the platform
+          if (!!subjectPredicate.self) {
+            return Resource.getSelf(subjectPredicate.self.value);
+          }
 
-        // otherwise it is not a resource, likely DOI or URI
-        return graphID;
-      });
+          // otherwise it is not a resource, likely DOI or URI
+          return Promise.resolve(graphID);
+        },
+      );
       const resources = await Promise.all(resourcePromises);
       return {
+        // total must be a number, so we use + to cast the string
+        // such as "2" into the number 2
         total: +(totalBinding ? totalBinding.total.value : 0),
         index: from,
         results: queryResults.map((subjectPredicate, index) => {

--- a/src/View/SparqlView/types.ts
+++ b/src/View/SparqlView/types.ts
@@ -17,7 +17,7 @@ export interface SparqlViewQueryResponse {
     bindings: {
       [key: string]: {
         type: string;
-        value: any;
+        value: string;
         datatype?: string;
         'xml:lang'?: string;
         [attribute: string]: any;


### PR DESCRIPTION
The total results received from SPARQL queries are strings, so this small update makes sure we cast them as numbers to keep in like with `PaginationSettings` and `PaginatedList` typings. 