### PR TITLE
👷‍♀️FIX: view fetch error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",

--- a/src/View/utils.ts
+++ b/src/View/utils.ts
@@ -97,9 +97,7 @@ export async function getView(
           viewResponse as SparqlViewResponse,
         );
   } catch (error) {
-    throw new Error(
-      `Not found: view "${viewId}" for project "${projectLabel}" in organization "${orgLabel}"`,
-    );
+    throw error;
   }
 }
 


### PR DESCRIPTION
Simply changes the get view method to throw the server response error instead of a custom one, which would incorrectly report `not found` when the error should have been `forbidden`. 

This will lead to less confusion in error reporting in nexus web.