### PR TITLE
👷‍♀️FIX: expanded link ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Resource.updateSelf = (selfUrl: string, rev: number, {
 Resource.deprecate = (orgLabel: string, projectLabel: string, schemaId: string, resourceId: string, rev: number): Promise<Resource>;
 Resource.deprecateSelf = (selfUrl: string, rev: number, orgLabel: string, projectLabel: string): Promise<Resource>;
 
+// Instance Methods
 resourceInstance.update({
     context,
     ...data
@@ -299,18 +300,21 @@ resourceInstance.update({
     [field: string]: any;
   }): Promise<Resource>;
 
+resourceInstance.getExpanded = () =>: Promise
+
+
 // Links! 🔗🔗🔗🔗
 
 const incomingLinks: PaginatedList<ResourceLinks> = await Resource.getIncomingLinks(
   orgLabel: string,
   projectLabel: string,
-  selfUrl: string,
+  expandedID: string,
   { from: 0, size: 20}: PaginationSettings);
 
 const outgoingLinks: PaginatedList<ResourceLinks> = await Resource.getOutgoingLinks(
   orgLabel: string,
   projectLabel: string,
-  selfUrl: string,
+  expandedID,
   { from: 0, size: 20}: PaginationSettings);
 
 const incomingLinks: PaginatedList<ResourceLinks> = await resourceInstance.getIncomingLinks({ from: 0, size: 20}: PaginationSettings);

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ const incomingLinks: PaginatedList<ResourceLinks> = await Resource.getIncomingLi
 const outgoingLinks: PaginatedList<ResourceLinks> = await Resource.getOutgoingLinks(
   orgLabel: string,
   projectLabel: string,
-  expandedID,
+  expandedID: string,
   { from: 0, size: 20}: PaginationSettings);
 
 const incomingLinks: PaginatedList<ResourceLinks> = await resourceInstance.getIncomingLinks({ from: 0, size: 20}: PaginationSettings);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2840,8 +2840,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2862,14 +2861,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2884,20 +2881,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3014,8 +3008,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3027,7 +3020,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3042,7 +3034,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3050,14 +3041,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3076,7 +3065,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3157,8 +3145,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3170,7 +3157,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3256,8 +3242,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3293,7 +3278,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3313,7 +3297,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3357,14 +3340,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3903,8 +3884,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.19",
+  "version": "1.0.0-beta.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.19",
+  "version": "1.0.0-beta.20",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",

--- a/src/Resource/__tests__/Resource.spec.ts
+++ b/src/Resource/__tests__/Resource.spec.ts
@@ -239,6 +239,29 @@ describe('Resource class', () => {
     });
   });
 
+  describe('Resource.getExpanded()', () => {
+    afterEach(() => {
+      fetchMock.resetMocks();
+    });
+    it('should fetch the expanded resource as an instance method', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ '@id': 'https://myfancyresourcelocation.com/myID' }),
+        {
+          status: 200,
+        },
+      );
+      const resource = new Resource(
+        'testOrg',
+        'testProject',
+        mockResourceResponse,
+      );
+      await resource.getExpanded();
+      expect(resource.expanded).toEqual({
+        '@id': 'https://myfancyresourcelocation.com/myID',
+      });
+    });
+  });
+
   describe('Resource.getAs()', () => {
     afterEach(() => {
       fetchMock.resetMocks();

--- a/src/Resource/__tests__/__snapshots__/links.spec.ts.snap
+++ b/src/Resource/__tests__/__snapshots__/links.spec.ts.snap
@@ -148,6 +148,46 @@ exports[`Incoming / Outgoing Links behavior getOutgoingLinks() should fetch a Pa
   "
 `;
 
+exports[`Incoming / Outgoing Links behavior getOutgoingLinks() should work having already the expanded resource 1`] = `
+"
+  prefix nxv: <https://bluebrain.github.io/nexus/vocabulary/>
+  SELECT ?total ?o ?p ?self
+
+  WITH {
+    SELECT DISTINCT ?p ?o ?self
+        WHERE {
+            graph <https://myExpandedResourceURl.com/someID/graph> {
+              ?s ?p ?o
+              FILTER(isIri(?o) && ?p NOT IN (nxv:updatedBy, nxv:createdBy, nxv:constrainedBy, nxv:project, rdf:type, nxv:self))
+            } .
+            OPTIONAL {
+              graph ?g2 {
+              	?o nxv:constrainedBy ?aSchema .
+                ?o nxv:self ?self
+                FILTER(?g2 != <https://myExpandedResourceURl.com/someID/graph>)
+              }
+            }
+      }
+} AS %resultSet
+
+
+  WHERE {
+     {
+        SELECT (COUNT(?o) AS ?total)
+        WHERE { INCLUDE %resultSet }
+     }
+     UNION
+    {
+        SELECT *
+        WHERE { INCLUDE %resultSet }
+        ORDER BY ?o ?p
+        LIMIT 20
+        OFFSET 0
+     }
+  }
+  "
+`;
+
 exports[`Incoming / Outgoing Links behavior getOutgoingLinks() should work just as well as a static method 1`] = `
 "
   prefix nxv: <https://bluebrain.github.io/nexus/vocabulary/>

--- a/src/Resource/__tests__/__snapshots__/links.spec.ts.snap
+++ b/src/Resource/__tests__/__snapshots__/links.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`Incoming / Outgoing Links behavior getIncomingLinks() should fetch a Pa
       WHERE {
         graph ?g1 {
 
-          ?ref ?p <https://bbp.epfl.ch/nexus/v0/data/bbp/morphology/reconstructedcell/v0.1.0/29d3a491-d3b7-49b6-9033-99017513a8ae> .
+          ?ref ?p <https://myExpandedResourceURl.com/someID> .
           ?s nxv:constrainedBy ?aSchema .
           ?s nxv:self ?self
 
@@ -72,6 +72,42 @@ exports[`Incoming / Outgoing Links behavior getIncomingLinks() should work as a 
     "
 `;
 
+exports[`Incoming / Outgoing Links behavior getIncomingLinks() should work having already the expanded resource 1`] = `
+"
+    prefix nxv: <https://bluebrain.github.io/nexus/vocabulary/>
+
+    SELECT ?total ?s ?p  ?self
+
+    WITH {
+      SELECT DISTINCT ?s ?p ?self
+      WHERE {
+        graph ?g1 {
+
+          ?ref ?p <https://myExpandedResourceURl.com/someID> .
+          ?s nxv:constrainedBy ?aSchema .
+          ?s nxv:self ?self
+
+        }
+      }
+    } AS %resultSet
+
+    WHERE {
+      {
+        SELECT (COUNT(?s) AS ?total)
+        WHERE { INCLUDE %resultSet }
+      }
+      UNION
+      {
+        SELECT *
+        WHERE { INCLUDE %resultSet }
+        ORDER BY ?s ?p
+        LIMIT 20
+        OFFSET 0
+       }
+      }
+    "
+`;
+
 exports[`Incoming / Outgoing Links behavior getOutgoingLinks() should fetch a PaginatedList of ResourceLinks using the proper SPAQRL queries as instance method 1`] = `
 "
   prefix nxv: <https://bluebrain.github.io/nexus/vocabulary/>
@@ -80,7 +116,7 @@ exports[`Incoming / Outgoing Links behavior getOutgoingLinks() should fetch a Pa
   WITH {
     SELECT DISTINCT ?p ?o ?self
         WHERE {
-            graph <https://bbp.epfl.ch/nexus/v0/data/bbp/morphology/reconstructedcell/v0.1.0/29d3a491-d3b7-49b6-9033-99017513a8ae/graph> {
+            graph <https://myExpandedResourceURl.com/someID/graph> {
               ?s ?p ?o
               FILTER(isIri(?o) && ?p NOT IN (nxv:updatedBy, nxv:createdBy, nxv:constrainedBy, nxv:project, rdf:type, nxv:self))
             } .
@@ -88,7 +124,7 @@ exports[`Incoming / Outgoing Links behavior getOutgoingLinks() should fetch a Pa
               graph ?g2 {
               	?o nxv:constrainedBy ?aSchema .
                 ?o nxv:self ?self
-                FILTER(?g2 != <https://bbp.epfl.ch/nexus/v0/data/bbp/morphology/reconstructedcell/v0.1.0/29d3a491-d3b7-49b6-9033-99017513a8ae/graph>)
+                FILTER(?g2 != <https://myExpandedResourceURl.com/someID/graph>)
               }
             }
       }

--- a/src/Resource/__tests__/links.spec.ts
+++ b/src/Resource/__tests__/links.spec.ts
@@ -177,6 +177,10 @@ describe('Incoming / Outgoing Links behavior', () => {
       }>('testOrg', 'testProject', mockGetByIDResourceResponse);
 
       fetchMock.mockResponses(
+        [
+          JSON.stringify({ '@id': 'https://myExpandedResourceURl.com/someID' }),
+          { status: 200 },
+        ],
         [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
         [JSON.stringify(mockIncomingLinksQueryResponse), { status: 200 }],
         [JSON.stringify(mockResourceResponse), { status: 200 }],
@@ -188,7 +192,39 @@ describe('Incoming / Outgoing Links behavior', () => {
         from: 0,
         size: 20,
       });
+      expect(resource.expanded).toEqual({
+        '@id': 'https://myExpandedResourceURl.com/someID',
+      });
+      expect(fetchMock.mock.calls[2][1].body).toMatchSnapshot();
+      expect(links.results[0]).toHaveProperty('predicate');
+      expect(links.results[0]).toHaveProperty('link');
+      expect(links.results[0].link).toBeInstanceOf(Resource);
+      fetchMock.resetMocks();
+    });
 
+    it('should work having already the expanded resource', async () => {
+      const resource = new Resource<{
+        subject: string;
+      }>('testOrg', 'testProject', mockGetByIDResourceResponse);
+      resource.expanded = {
+        '@id': 'https://myExpandedResourceURl.com/someID',
+      } as any;
+
+      fetchMock.mockResponses(
+        [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
+        [JSON.stringify(mockIncomingLinksQueryResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+      );
+      const links: PaginatedList<
+        ResourceLink
+      > = await resource.getIncomingLinks({
+        from: 0,
+        size: 20,
+      });
+      expect(resource.expanded).toEqual({
+        '@id': 'https://myExpandedResourceURl.com/someID',
+      });
       expect(fetchMock.mock.calls[1][1].body).toMatchSnapshot();
       expect(links.results[0]).toHaveProperty('predicate');
       expect(links.results[0]).toHaveProperty('link');
@@ -230,6 +266,10 @@ describe('Incoming / Outgoing Links behavior', () => {
       }>('testOrg', 'testProject', mockGetByIDResourceResponse);
 
       fetchMock.mockResponses(
+        [
+          JSON.stringify({ '@id': 'https://myExpandedResourceURl.com/someID' }),
+          { status: 200 },
+        ],
         [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
         [JSON.stringify(mockOutgoingLinksQueryResponse), { status: 200 }],
         [JSON.stringify(mockResourceResponse), { status: 200 }],
@@ -243,7 +283,10 @@ describe('Incoming / Outgoing Links behavior', () => {
         size: 20,
       });
 
-      expect(fetchMock.mock.calls[1][1].body).toMatchSnapshot();
+      expect(resource.expanded).toEqual({
+        '@id': 'https://myExpandedResourceURl.com/someID',
+      });
+      expect(fetchMock.mock.calls[2][1].body).toMatchSnapshot();
       expect(links.results[0]).toHaveProperty('predicate');
       expect(links.results[0]).toHaveProperty('link');
       expect(links.results[1].link).toBeInstanceOf(Resource);

--- a/src/Resource/__tests__/links.spec.ts
+++ b/src/Resource/__tests__/links.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../../__mocks__/helpers';
 import { SparqlViewQueryResponse } from '../../View/SparqlView/types';
 import { PaginatedList } from '../../utils/types';
-import { ResourceLink } from '../types';
+import { ResourceLink, ExpandedResource } from '../types';
 import { getIncomingLinks, getOutgoingLinks, getLinks } from '../utils';
 
 const { fetchMock } = <GlobalWithFetchMock>global;
@@ -208,7 +208,7 @@ describe('Incoming / Outgoing Links behavior', () => {
       }>('testOrg', 'testProject', mockGetByIDResourceResponse);
       resource.expanded = {
         '@id': 'https://myExpandedResourceURl.com/someID',
-      } as any;
+      };
 
       fetchMock.mockResponses(
         [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
@@ -299,7 +299,7 @@ describe('Incoming / Outgoing Links behavior', () => {
       }>('testOrg', 'testProject', mockGetByIDResourceResponse);
       resource.expanded = {
         '@id': 'https://myExpandedResourceURl.com/someID',
-      } as any;
+      };
 
       fetchMock.mockResponses(
         [JSON.stringify(mockSparqlViewResponse), { status: 200 }],

--- a/src/Resource/__tests__/links.spec.ts
+++ b/src/Resource/__tests__/links.spec.ts
@@ -293,6 +293,36 @@ describe('Incoming / Outgoing Links behavior', () => {
       fetchMock.resetMocks();
     });
 
+    it('should work having already the expanded resource', async () => {
+      const resource = new Resource<{
+        subject: string;
+      }>('testOrg', 'testProject', mockGetByIDResourceResponse);
+      resource.expanded = {
+        '@id': 'https://myExpandedResourceURl.com/someID',
+      } as any;
+
+      fetchMock.mockResponses(
+        [JSON.stringify(mockSparqlViewResponse), { status: 200 }],
+        [JSON.stringify(mockIncomingLinksQueryResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+        [JSON.stringify(mockResourceResponse), { status: 200 }],
+      );
+      const links: PaginatedList<
+        ResourceLink
+      > = await resource.getOutgoingLinks({
+        from: 0,
+        size: 20,
+      });
+      expect(resource.expanded).toEqual({
+        '@id': 'https://myExpandedResourceURl.com/someID',
+      });
+      expect(fetchMock.mock.calls[1][1].body).toMatchSnapshot();
+      expect(links.results[0]).toHaveProperty('predicate');
+      expect(links.results[0]).toHaveProperty('link');
+      expect(links.results[0].link).toBeInstanceOf(Resource);
+      fetchMock.resetMocks();
+    });
+
     it('should work just as well as a static method', async () => {
       fetchMock.mockResponses(
         [JSON.stringify(mockSparqlViewResponse), { status: 200 }],

--- a/src/Resource/index.ts
+++ b/src/Resource/index.ts
@@ -160,13 +160,24 @@ export default class Resource<T = {}> {
     );
   }
 
+  async getExpanded() {
+    this.expanded = await getSelfResourceRawAs(`${this.self}?format=expanded`);
+  }
+
   async getIncomingLinks(
     paginationSettings: PaginationSettings,
   ): Promise<PaginatedList<ResourceLink>> {
+    let expandedID;
+    if (this.expanded && (this.expanded as any)['@id']) {
+      expandedID = (this.expanded as any)['@id'];
+    } else {
+      await this.getExpanded();
+      expandedID = (this.expanded as any)['@id'];
+    }
     return await getIncomingLinks(
       this.orgLabel,
       this.projectLabel,
-      this.id,
+      expandedID,
       paginationSettings,
     );
   }
@@ -174,10 +185,17 @@ export default class Resource<T = {}> {
   async getOutgoingLinks(
     paginationSettings: PaginationSettings,
   ): Promise<PaginatedList<ResourceLink>> {
+    let expandedID;
+    if (this.expanded && (this.expanded as any)['@id']) {
+      expandedID = (this.expanded as any)['@id'];
+    } else {
+      await this.getExpanded();
+      expandedID = (this.expanded as any)['@id'];
+    }
     return await getOutgoingLinks(
       this.orgLabel,
       this.projectLabel,
-      this.id,
+      expandedID,
       paginationSettings,
     );
   }

--- a/src/Resource/index.ts
+++ b/src/Resource/index.ts
@@ -4,6 +4,7 @@ import {
   ResourceGetFormats,
   GetResourceOptions,
   ResourceLink,
+  ExpandedResource,
 } from './types';
 import {
   getResource,
@@ -61,7 +62,7 @@ export default class Resource<T = {}> {
   readonly data: T;
   readonly raw: ResourceResponse;
   readonly resourceURL: string;
-  expanded?: JSON;
+  expanded?: ExpandedResource;
 
   static getSelf = getSelfResource;
   static getSelfRawAs = getSelfResourceRawAs;
@@ -162,17 +163,18 @@ export default class Resource<T = {}> {
 
   async getExpanded() {
     this.expanded = await getSelfResourceRawAs(`${this.self}?format=expanded`);
+    return this.expanded;
   }
 
   async getIncomingLinks(
     paginationSettings: PaginationSettings,
   ): Promise<PaginatedList<ResourceLink>> {
     let expandedID;
-    if (this.expanded && (this.expanded as any)['@id']) {
-      expandedID = (this.expanded as any)['@id'];
+    if (this.expanded && this.expanded['@id']) {
+      expandedID = this.expanded['@id'];
     } else {
       await this.getExpanded();
-      expandedID = (this.expanded as any)['@id'];
+      expandedID = (this.expanded as ExpandedResource)['@id'];
     }
     return await getIncomingLinks(
       this.orgLabel,
@@ -186,11 +188,11 @@ export default class Resource<T = {}> {
     paginationSettings: PaginationSettings,
   ): Promise<PaginatedList<ResourceLink>> {
     let expandedID;
-    if (this.expanded && (this.expanded as any)['@id']) {
-      expandedID = (this.expanded as any)['@id'];
+    if (this.expanded && this.expanded['@id']) {
+      expandedID = this.expanded['@id'];
     } else {
       await this.getExpanded();
-      expandedID = (this.expanded as any)['@id'];
+      expandedID = (this.expanded as ExpandedResource)['@id'];
     }
     return await getOutgoingLinks(
       this.orgLabel,

--- a/src/Resource/types.ts
+++ b/src/Resource/types.ts
@@ -87,3 +87,8 @@ export interface ResourceLink {
   isExternal: boolean;
   predicate: string; // url vocab link such as https://myNexusInstance.com/vocabs/myOrg/friendProject/friend
 }
+
+export interface ExpandedResource {
+  '@id': string;
+  [uriKey: string]: any;
+}

--- a/src/Resource/types.ts
+++ b/src/Resource/types.ts
@@ -90,5 +90,6 @@ export interface ResourceLink {
 
 export interface ExpandedResource {
   '@id': string;
+  '@type'?: string[];
   [uriKey: string]: any;
 }

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -365,7 +365,7 @@ export async function getOutgoingLinks(
               graph ?g2 {
               	?o nxv:constrainedBy ?aSchema .
                 ?o nxv:self ?self
-                FILTER(?g2 != <${id}/graph>)
+                FILTER(?g2 != <${expandedID}/graph>)
               }
             }
       }

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -343,7 +343,7 @@ export async function deprecateSelfResource(
 export async function getOutgoingLinks(
   orgLabel: string,
   projectLabel: string,
-  id: string,
+  expandedID: string,
   paginationSettings: PaginationSettings,
 ): Promise<PaginatedList<ResourceLink>> {
   return await getLinks(
@@ -357,7 +357,7 @@ export async function getOutgoingLinks(
   WITH {
     SELECT DISTINCT ?p ?o ?self
         WHERE {
-            graph <${id}/graph> {
+            graph <${expandedID}/graph> {
               ?s ?p ?o
               FILTER(isIri(?o) && ?p NOT IN (nxv:updatedBy, nxv:createdBy, nxv:constrainedBy, nxv:project, rdf:type, nxv:self))
             } .
@@ -393,7 +393,7 @@ export async function getOutgoingLinks(
 export async function getIncomingLinks(
   orgLabel: string,
   projectLabel: string,
-  id: string,
+  expandedID: string,
   paginationSettings: PaginationSettings,
 ): Promise<PaginatedList<ResourceLink>> {
   return await getLinks(
@@ -410,7 +410,7 @@ export async function getIncomingLinks(
       WHERE {
         graph ?g1 {
 
-          ?ref ?p <${id}> .
+          ?ref ?p <${expandedID}> .
           ?s nxv:constrainedBy ?aSchema .
           ?s nxv:self ?self
 


### PR DESCRIPTION
Fixes a problem where some links would be missing because of SPAQL shenanigans. 

Link methods now require as a param an expanded `@id` instead of the unresolved `@id` that you would normally get as a getByID response from the server. 

the instance methods to get links will fetch the expanded resource if it wasn't expanded already in order to get this expanded `@id`.

@julienmachon you will be happy to know that this resolves the missing links betwixt your inventory of Roux sauces. 

