### PR TITLE
👷‍♀️FIX: file path building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",

--- a/src/Resource/__tests__/Resource.spec.ts
+++ b/src/Resource/__tests__/Resource.spec.ts
@@ -374,6 +374,15 @@ describe('Resource class', () => {
       expect(r).toHaveProperty('orgLabel', 'myOrg');
       expect(r).toHaveProperty('projectLabel', 'myProject');
     });
+    it('should assign the proper orgLabel even if the selfURL has files', async () => {
+      const r: Resource = await getSelfResource(
+        'http://myurl.com/staging/v1/something/somethingelse/files/myOrg/myProject/myFIleID',
+        { expanded: true },
+      );
+      expect(r).toBeInstanceOf(Resource);
+      expect(r).toHaveProperty('orgLabel', 'myOrg');
+      expect(r).toHaveProperty('projectLabel', 'myProject');
+    });
   });
 
   describe('createResource()', () => {

--- a/src/Resource/__tests__/Resource.spec.ts
+++ b/src/Resource/__tests__/Resource.spec.ts
@@ -388,7 +388,6 @@ describe('Resource class', () => {
         'http://myurl.com/staging/v1/something/somethingelse/resources/testOrgA/myProjectB/mySchema/I-love-files-but-i-am-not-one-of-them',
         { expanded: true },
       );
-      console.log(r);
       expect(r).toBeInstanceOf(Resource);
       expect(r).toHaveProperty('orgLabel', 'testOrgA');
       expect(r).toHaveProperty('projectLabel', 'myProjectB');

--- a/src/Resource/__tests__/Resource.spec.ts
+++ b/src/Resource/__tests__/Resource.spec.ts
@@ -376,12 +376,22 @@ describe('Resource class', () => {
     });
     it('should assign the proper orgLabel even if the selfURL has files', async () => {
       const r: Resource = await getSelfResource(
-        'http://myurl.com/staging/v1/something/somethingelse/files/myOrg/myProject/myFIleID',
+        'http://myurl.com/staging/v1/something/somethingelse/files/myOrgABC/myProjectABC/myFileID',
         { expanded: true },
       );
       expect(r).toBeInstanceOf(Resource);
-      expect(r).toHaveProperty('orgLabel', 'myOrg');
-      expect(r).toHaveProperty('projectLabel', 'myProject');
+      expect(r).toHaveProperty('orgLabel', 'myOrgABC');
+      expect(r).toHaveProperty('projectLabel', 'myProjectABC');
+    });
+    it('should assign the proper orgLabel even if the selfURL has files but it isnt a real file', async () => {
+      const r: Resource = await getSelfResource(
+        'http://myurl.com/staging/v1/something/somethingelse/resources/testOrgA/myProjectB/mySchema/I-love-files-but-i-am-not-one-of-them',
+        { expanded: true },
+      );
+      console.log(r);
+      expect(r).toBeInstanceOf(Resource);
+      expect(r).toHaveProperty('orgLabel', 'testOrgA');
+      expect(r).toHaveProperty('projectLabel', 'myProjectB');
     });
   });
 

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -240,10 +240,21 @@ export default function makeResourceUtils(store: Store): ResourceUtils {
         let orgLabel;
         let rest;
 
-        if (selfUrl.includes(FILES_PATH_LABEL)) {
-          [, projectLabel, orgLabel, ...rest] = selfUrl.split('/').reverse();
+        // in the case of a file, this will be FILES_PATH_LABEL
+        // however in the normal case this will be the location
+        // of the orgLabel within the path
+        // this is because files are treated specially and have no
+        // schemas in their path.
+        const resourceAccessType = [...selfUrl.split('/')].reverse()[3];
+
+        if (resourceAccessType === FILES_PATH_LABEL) {
+          [, projectLabel, orgLabel, ...rest] = [
+            ...selfUrl.split('/'),
+          ].reverse();
         } else {
-          [, , projectLabel, orgLabel, ...rest] = selfUrl.split('/').reverse();
+          [, , projectLabel, orgLabel, ...rest] = [
+            ...selfUrl.split('/'),
+          ].reverse();
         }
 
         const resourceResponse: ResourceResponse = await getSelfResourceRawAs(

--- a/src/Resource/utils.ts
+++ b/src/Resource/utils.ts
@@ -23,6 +23,8 @@ import { SparqlViewQueryResponse } from '../View/SparqlView/types';
 import { getSparqlView } from '../View/utils';
 import Store from '../utils/Store';
 
+const FILES_PATH_LABEL = 'files';
+
 export interface ResourceUtils {
   getSelfRawAs(selfUrl: string, format?: ResourceGetFormats): Promise<any>;
   getSelf(
@@ -234,9 +236,16 @@ export default function makeResourceUtils(store: Store): ResourceUtils {
       getResourceOptions: GetResourceOptions = DEFAULT_GET_RESOURCE_OPTIONS,
     ): Promise<Resource> => {
       try {
-        const [id, schema, projectLabel, orgLabel, ...rest] = selfUrl
-          .split('/')
-          .reverse();
+        let projectLabel;
+        let orgLabel;
+        let rest;
+
+        if (selfUrl.includes(FILES_PATH_LABEL)) {
+          [, projectLabel, orgLabel, ...rest] = selfUrl.split('/').reverse();
+        } else {
+          [, , projectLabel, orgLabel, ...rest] = selfUrl.split('/').reverse();
+        }
+
         const resourceResponse: ResourceResponse = await getSelfResourceRawAs(
           selfUrl,
         );


### PR DESCRIPTION
now when creating a resource instance with `Resource.getSelf` the sdk will check for the `files` path and parse the url correctly. Before this caused problems because file resources don't have schemas in their paths. 

