### PR TITLE
👷‍♀️FIX: view query url

### DIFF
--- a/src/View/AggregateSparqlView/__tests__/__snapshots__/AggregateSparqlView.spec.ts.snap
+++ b/src/View/AggregateSparqlView/__tests__/__snapshots__/AggregateSparqlView.spec.ts.snap
@@ -6,7 +6,7 @@ AggregateSparqlView {
   "id": "http://example.com/base/aggregated",
   "orgLabel": "myOrg",
   "projectLabel": "myProject",
-  "queryURL": "/views/myOrg/myProject/http://example.com/base/aggregated/sparql",
+  "queryURL": "/views/myOrg/myProject/http%3A%2F%2Fexample.com%2Fbase%2Faggregated/sparql",
   "rev": 1,
   "type": Array [
     "View",

--- a/src/View/ElasticSearchView/__tests__/ElasticSearchView.spec.ts
+++ b/src/View/ElasticSearchView/__tests__/ElasticSearchView.spec.ts
@@ -54,9 +54,9 @@ describe('ElasticSearchView class', () => {
       projectLabel,
       mockElasticSearchViewResponse,
     );
-    const expectedQueryURL = `/views/${orgLabel}/${projectLabel}/${
-      view.id
-    }/_search`;
+    const expectedQueryURL = `/views/${orgLabel}/${projectLabel}/${encodeURIComponent(
+      view.id,
+    )}/_search`;
     expect(view.queryURL).toEqual(expectedQueryURL);
   });
 
@@ -71,17 +71,14 @@ describe('ElasticSearchView class', () => {
       );
       const myQuery = {};
       fetchMock.mockResponses(
+        [JSON.stringify(mockElasticSearchViewQueryResponse), { status: 200 }],
         [
-          JSON.stringify(mockElasticSearchViewQueryResponse),
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 1st inner fetch for Resource
+          { status: 200 },
         ],
         [
-          JSON.stringify(mockResourceResponse),  // 1st inner fetch for Resource
-          { status: 200 }
-        ],
-        [
-          JSON.stringify(mockResourceResponse),  // 2nd inner fetch for expanded Resource
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 2nd inner fetch for expanded Resource
+          { status: 200 },
         ],
         [
           JSON.stringify(mockElasticSearchViewAggregationResponse),
@@ -117,17 +114,14 @@ describe('ElasticSearchView class', () => {
         size: 20,
       };
       fetchMock.mockResponses(
+        [JSON.stringify(mockElasticSearchViewQueryResponse), { status: 200 }],
         [
-          JSON.stringify(mockElasticSearchViewQueryResponse),
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 1st inner fetch for Resource
+          { status: 200 },
         ],
         [
-          JSON.stringify(mockResourceResponse),  // 1st inner fetch for Resource
-          { status: 200 }
-        ],
-        [
-          JSON.stringify(mockResourceResponse),  // 2nd inner fetch for expanded Resource
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 2nd inner fetch for expanded Resource
+          { status: 200 },
         ],
         [
           JSON.stringify(mockElasticSearchViewAggregationResponse),
@@ -135,9 +129,9 @@ describe('ElasticSearchView class', () => {
         ],
       );
       await view.query(myQuery, myPaginationSettings);
-      const expectedQueryURL = `/views/${orgLabel}/${projectLabel}/${
-        view.id
-      }/_search?from=${myPaginationSettings.from}&size=${
+      const expectedQueryURL = `/views/${orgLabel}/${projectLabel}/${encodeURIComponent(
+        view.id,
+      )}/_search?from=${myPaginationSettings.from}&size=${
         myPaginationSettings.size
       }`;
       expect(fetchMock.mock.calls[0][0]).toEqual(baseUrl + expectedQueryURL);
@@ -152,17 +146,14 @@ describe('ElasticSearchView class', () => {
       );
       const myQuery = {};
       fetchMock.mockResponses(
+        [JSON.stringify(mockElasticSearchViewQueryResponse), { status: 200 }],
         [
-          JSON.stringify(mockElasticSearchViewQueryResponse),
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 1st inner fetch for Resource
+          { status: 200 },
         ],
         [
-          JSON.stringify(mockResourceResponse),  // 1st inner fetch for Resource
-          { status: 200 }
-        ],
-        [
-          JSON.stringify(mockResourceResponse),  // 2nd inner fetch for expanded Resource
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 2nd inner fetch for expanded Resource
+          { status: 200 },
         ],
         [
           JSON.stringify(mockElasticSearchViewAggregationResponse),
@@ -186,17 +177,14 @@ describe('ElasticSearchView class', () => {
       );
       const myQuery = {};
       fetchMock.mockResponses(
+        [JSON.stringify(mockElasticSearchViewQueryResponse), { status: 200 }],
         [
-          JSON.stringify(mockElasticSearchViewQueryResponse),
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 1st inner fetch for Resource
+          { status: 200 },
         ],
         [
-          JSON.stringify(mockResourceResponse),  // 1st inner fetch for Resource
-          { status: 200 }
-        ],
-        [
-          JSON.stringify(mockResourceResponse),  // 2nd inner fetch for expanded Resource
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 2nd inner fetch for expanded Resource
+          { status: 200 },
         ],
         [
           JSON.stringify(mockElasticSearchViewAggregationResponse),
@@ -232,17 +220,14 @@ describe('ElasticSearchView class', () => {
         size: 20,
       };
       fetchMock.mockResponses(
+        [JSON.stringify(mockElasticSearchViewQueryResponse), { status: 200 }],
         [
-          JSON.stringify(mockElasticSearchViewQueryResponse),
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 1st inner fetch for Resource
+          { status: 200 },
         ],
         [
-          JSON.stringify(mockResourceResponse),  // 1st inner fetch for Resource
-          { status: 200 }
-        ],
-        [
-          JSON.stringify(mockResourceResponse),  // 2nd inner fetch for expanded Resource
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 2nd inner fetch for expanded Resource
+          { status: 200 },
         ],
         [
           JSON.stringify(mockElasticSearchViewAggregationResponse),
@@ -250,9 +235,9 @@ describe('ElasticSearchView class', () => {
         ],
       );
       await view.rawQuery(myQuery, myPaginationSettings);
-      const expectedQueryURL = `/views/${orgLabel}/${projectLabel}/${
-        view.id
-      }/_search?from=${myPaginationSettings.from}&size=${
+      const expectedQueryURL = `/views/${orgLabel}/${projectLabel}/${encodeURIComponent(
+        view.id,
+      )}/_search?from=${myPaginationSettings.from}&size=${
         myPaginationSettings.size
       }`;
       expect(fetchMock.mock.calls[0][0]).toEqual(baseUrl + expectedQueryURL);
@@ -267,17 +252,14 @@ describe('ElasticSearchView class', () => {
       );
       const myQuery = {};
       fetchMock.mockResponses(
+        [JSON.stringify(mockElasticSearchViewQueryResponse), { status: 200 }],
         [
-          JSON.stringify(mockElasticSearchViewQueryResponse),
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 1st inner fetch for Resource
+          { status: 200 },
         ],
         [
-          JSON.stringify(mockResourceResponse),  // 1st inner fetch for Resource
-          { status: 200 }
-        ],
-        [
-          JSON.stringify(mockResourceResponse),  // 2nd inner fetch for expanded Resource
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 2nd inner fetch for expanded Resource
+          { status: 200 },
         ],
         [
           JSON.stringify(mockElasticSearchViewAggregationResponse),
@@ -350,17 +332,14 @@ describe('ElasticSearchView class', () => {
     beforeEach(() => {
       // Mock our query response
       fetchMock.mockResponses(
+        [JSON.stringify(mockElasticSearchViewQueryResponse), { status: 200 }],
         [
-          JSON.stringify(mockElasticSearchViewQueryResponse),
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 1st inner fetch for Resource
+          { status: 200 },
         ],
         [
-          JSON.stringify(mockResourceResponse),  // 1st inner fetch for Resource
-          { status: 200 }
-        ],
-        [
-          JSON.stringify(mockResourceResponse),  // 2nd inner fetch for expanded Resource
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 2nd inner fetch for expanded Resource
+          { status: 200 },
         ],
       );
     });
@@ -438,17 +417,14 @@ describe('ElasticSearchView class', () => {
     beforeEach(() => {
       // Mock our query response
       fetchMock.mockResponses(
+        [JSON.stringify(mockElasticSearchViewQueryResponse), { status: 200 }],
         [
-          JSON.stringify(mockElasticSearchViewQueryResponse),
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 1st inner fetch for Resource
+          { status: 200 },
         ],
         [
-          JSON.stringify(mockResourceResponse),  // 1st inner fetch for Resource
-          { status: 200 }
-        ],
-        [
-          JSON.stringify(mockResourceResponse),  // 2nd inner fetch for expanded Resource
-          { status: 200 }
+          JSON.stringify(mockResourceResponse), // 2nd inner fetch for expanded Resource
+          { status: 200 },
         ],
       );
     });

--- a/src/View/ElasticSearchView/index.ts
+++ b/src/View/ElasticSearchView/index.ts
@@ -38,9 +38,9 @@ export default class ElasticSearchView {
     this.uuid = elasticSearchViewResponse['_uuid'];
     this.rev = elasticSearchViewResponse['_rev'];
     this.deprecated = elasticSearchViewResponse['_deprecated'];
-    this.queryURL = `/views/${this.orgLabel}/${this.projectLabel}/${
-      this.id
-    }/_search`;
+    this.queryURL = `/views/${this.orgLabel}/${
+      this.projectLabel
+    }/${encodeURIComponent(this.id)}/_search`;
   }
 
   static get = getElasticSearchView;

--- a/src/View/SparqlView/index.ts
+++ b/src/View/SparqlView/index.ts
@@ -24,9 +24,9 @@ export default class SparqlView {
     this.uuid = sparqlViewResponse['_uuid'];
     this.rev = sparqlViewResponse['_rev'];
     this.deprecated = sparqlViewResponse['_deprecated'];
-    this.queryURL = `/views/${this.orgLabel}/${this.projectLabel}/${
-      this.id
-    }/sparql`;
+    this.queryURL = `/views/${this.orgLabel}/${
+      this.projectLabel
+    }/${encodeURIComponent(this.id)}/sparql`;
   }
 
   static get = getSparqlView;

--- a/src/View/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/src/View/__tests__/__snapshots__/utils.spec.ts.snap
@@ -7,7 +7,7 @@ Array [
     "id": "nxv:myview2",
     "orgLabel": "myorg",
     "projectLabel": "myproject",
-    "queryURL": "/views/myorg/myproject/nxv:myview2/_search",
+    "queryURL": "/views/myorg/myproject/nxv%3Amyview2/_search",
     "rev": 4,
     "type": Array [
       "ElasticSearchView",
@@ -21,7 +21,7 @@ Array [
     "id": "nxv:myview",
     "orgLabel": "myorg",
     "projectLabel": "myproject",
-    "queryURL": "/views/myorg/myproject/nxv:myview/sparql",
+    "queryURL": "/views/myorg/myproject/nxv%3Amyview/sparql",
     "rev": 4,
     "type": Array [
       "SparqlView",


### PR DESCRIPTION
myView.queryURL is now properly formatted with a uri-encoded `@id` that prevented queries to work on non-default views. 