### PR TITLE
👷‍♀️ FIX: change types for poll, list and get

### DIFF
--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -14,22 +14,22 @@ const Resource = (
   context: NexusContext,
 ) => {
   return {
-    get: (
+    get: <T = {}>(
       orgLabel: string,
       projectLabel: string,
       resourceId: string,
       options?: GetResourceOptions,
-    ): Promise<Resource> =>
+    ): Promise<Resource & T> =>
       httpGet({
         path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${
           DEFAULTS.SCHEMA_ID
         }/${resourceId}${buildQueryParams(options)}`,
       }),
-    list: (
+    list: <T = {}>(
       orgLabel: string,
       projectLabel: string,
       options?: ResourceListOptions,
-    ): Promise<PaginatedResource> => {
+    ): Promise<PaginatedResource<Resource & T>> => {
       const opts = buildQueryParams(options);
       return httpGet({
         path: `${context.uri}/resources/${orgLabel}/${projectLabel}${opts}`,
@@ -86,12 +86,12 @@ const Resource = (
         }/resources/${orgLabel}/${projectLabel}/${schemaId ||
           DEFAULTS.SCHEMA_ID}/${resourceId}?rev=${rev}`,
       }),
-    poll: (
+    poll: <T = {}>(
       orgLabel: string,
       projectLabel: string,
       resourceId: string,
       options?: GetResourceOptions & { pollTime: number },
-    ): Observable<Resource> => {
+    ): Observable<Resource & T> => {
       const { pollTime, ...getResourceOptions } = options;
       return poll({
         path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -1,11 +1,6 @@
 import { Observable } from '@bbp/nexus-link';
 import { Fetchers, GetResourceOptions, Resource } from '../types';
-import {
-  ResourceListOptions,
-  ResourcePayload,
-  PaginatedResource,
-  ResourceList,
-} from './types';
+import { ResourceListOptions, ResourcePayload, ResourceList } from './types';
 import { NexusContext } from '../nexusSdk';
 import { buildQueryParams } from '../utils';
 import { DEFAULTS } from '../constants';

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -4,6 +4,7 @@ import {
   ResourceListOptions,
   ResourcePayload,
   PaginatedResource,
+  ResourceList,
 } from './types';
 import { NexusContext } from '../nexusSdk';
 import { buildQueryParams } from '../utils';
@@ -14,7 +15,7 @@ const Resource = (
   context: NexusContext,
 ) => {
   return {
-    get: <T = {}>(
+    get: <T>(
       orgLabel: string,
       projectLabel: string,
       resourceId: string,
@@ -25,11 +26,11 @@ const Resource = (
           DEFAULTS.SCHEMA_ID
         }/${resourceId}${buildQueryParams(options)}`,
       }),
-    list: <T = {}>(
+    list: <T>(
       orgLabel: string,
       projectLabel: string,
       options?: ResourceListOptions,
-    ): Promise<PaginatedResource<Resource & T>> => {
+    ): Promise<ResourceList<T>> => {
       const opts = buildQueryParams(options);
       return httpGet({
         path: `${context.uri}/resources/${orgLabel}/${projectLabel}${opts}`,
@@ -86,7 +87,7 @@ const Resource = (
         }/resources/${orgLabel}/${projectLabel}/${schemaId ||
           DEFAULTS.SCHEMA_ID}/${resourceId}?rev=${rev}`,
       }),
-    poll: <T = {}>(
+    poll: <T>(
       orgLabel: string,
       projectLabel: string,
       resourceId: string,

--- a/packages/nexus-sdk/src/Resource/types.ts
+++ b/packages/nexus-sdk/src/Resource/types.ts
@@ -44,6 +44,8 @@ export type PaginatedResource<T = Resource> = {
   _next?: string;
 };
 
+export type ResourceList<T> = PaginatedResource<Resource & T>;
+
 export type GetResourceOptions = {
   rev?: number;
   tag?: string;


### PR DESCRIPTION
Fixes types for polling, listing, and getting so you can (optionally) do stuff like:

```typescript
type Person = { name: string };
const person = await nexus.Resource.get<Person>('org', 'proj', 'myId');

// Metadata types are still there
console.log(person["@id"]); // myId

// Won't throw an error!
console.log(person.name)
```

However, creating, updating, and deprecating a resource will always return the vanilla  `Resource` type because they just give back the metadata alone. 